### PR TITLE
Adapt to ehForwarderBot 2.1.1.dev1

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -14,7 +14,7 @@ from typing import Optional, Collection, BinaryIO, Dict, Any , Union , List
 from datetime import datetime
 from cachetools import TTLCache
 
-from ehforwarderbot import MsgType, Chat, Message, Status, coordinator
+from ehforwarderbot import MsgType, Chat, Message, Status, coordinator, ChatMember
 from wechatrobot import WeChatRobot
 
 from . import __version__ as version
@@ -565,6 +565,14 @@ class ComWeChatChannel(SlaveChannel):
 
     def get_chat_picture(self, chat: 'Chat') -> BinaryIO:
         wxid = chat.uid
+        result = self.bot.GetPictureBySql(wxid = wxid)
+        if result:
+            return download_file(result)
+        else:
+            return None
+
+    def get_chat_member_picture(self, chat_member: 'ChatMember') -> BinaryIO:
+        wxid = chat_member.uid
         result = self.bot.GetPictureBySql(wxid = wxid)
         if result:
             return download_file(result)

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -9,12 +9,12 @@ import os
 import re
 import time
 import json
-from ehforwarderbot.chat import PrivateChat , SystemChatMember
+from ehforwarderbot.chat import PrivateChat , SystemChatMember, ChatMember
 from typing import Optional, Collection, BinaryIO, Dict, Any , Union , List
 from datetime import datetime
 from cachetools import TTLCache
 
-from ehforwarderbot import MsgType, Chat, Message, Status, coordinator, ChatMember
+from ehforwarderbot import MsgType, Chat, Message, Status, coordinator
 from wechatrobot import WeChatRobot
 
 from . import __version__ as version


### PR DESCRIPTION
I noticed that ehforwarderbot only allows to use get_chat_picture method to get group avatars or private chat avatars, but it cannot get the avatar of a specific message sender. So try to add get_chat_member_picture method to solve this problem. This requires both the framework and the slaves to make corresponding adaptations.