### PR TITLE
fix(chat): handle missing group chat nicknames

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -623,7 +623,7 @@ class ComWeChatChannel(SlaveChannel):
                         name = self.contacts[wxid]
                     except:
                         try:
-                            name = self.bot.GetChatroomMemberNickname(chatroom_id = chat_uid, wxid = wxid)
+                            name = self.bot.GetChatroomMemberNickname(chatroom_id = chat_uid, wxid = wxid)['nickname'] or wxid
                         except:
                             name = wxid
                     message += '\n' + wxid + ' : ' + name


### PR DESCRIPTION
GetChatroomMemberNickname 返回的一个 dict，不是 string