### PR TITLE
fix: fix quote message campatibility

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -795,7 +795,11 @@ class ComWeChatChannel(SlaveChannel):
                     msgid = msg.target.uid
                     sender = msg.target.author.uid
                     displayname = msg.target.author.name
-                    content = escape(msg.target.vendor_specific.get("wx_xml", ""))
+                    content = escape(msg.target.vendor_specific.get("wx_xml", ""), {
+                        "\n": "&#x0A;",
+                        "\t": "&#x09;",
+                        '"': "&quot;",
+                    })
                     comwechat_info = msg.target.vendor_specific.get("comwechat_info", {})
                     if comwechat_info.get("type", None) == "animatedsticker":
                         refer_type = 47

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -35,7 +35,7 @@ from .CustomTypes import EFBGroupChat, EFBPrivateChat, EFBGroupMember, EFBSystem
 from .MsgDeco import qutoed_text
 from .MsgProcess import MsgProcess, MsgWrapper
 from .Utils import download_file , load_config , load_temp_file_to_local , WC_EMOTICON_CONVERSION
-from .Constant import QUOTE_MESSAGE, QUOTE_GROUP_MESSAGE
+from .Constant import QUOTE_MESSAGE
 
 from rich.console import Console
 from rich import print as rprint
@@ -501,7 +501,7 @@ class ComWeChatChannel(SlaveChannel):
             self.file_msg[msg["filepath"]] = ( msg , author , chat )
             return
 
-        self.send_efb_msgs(MsgWrapper(msg["message"], MsgProcess(msg, chat)), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
+        self.send_efb_msgs(MsgWrapper(msg, MsgProcess(msg, chat)), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
 
     def handle_file_msg(self):
         while True:
@@ -533,7 +533,7 @@ class ComWeChatChannel(SlaveChannel):
 
                     if flag:
                         del self.file_msg[path]
-                        self.send_efb_msgs(MsgWrapper(msg["message"], MsgProcess(msg, chat)), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
+                        self.send_efb_msgs(MsgWrapper(msg, MsgProcess(msg, chat)), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
 
             if len(self.delete_file):
                 for k in list(self.delete_file.keys()):
@@ -796,14 +796,30 @@ class ComWeChatChannel(SlaveChannel):
                     sender = msg.target.author.uid
                     displayname = msg.target.author.name
                     content = escape(msg.target.vendor_specific.get("wx_xml", ""))
+                    comwechat_info = msg.target.vendor_specific.get("comwechat_info", {})
+                    if comwechat_info.get("type", None) == "animatedsticker":
+                        refer_type = 47
+                    elif msg.target.type == MsgType.Image:
+                        refer_type = 3
+                    elif msg.target.type == MsgType.Voice:
+                        refer_type = 34
+                    elif msg.target.type == MsgType.Video:
+                        refer_type = 43
+                    elif msg.target.type == MsgType.Sticker:
+                        refer_type = 47
+                    elif msg.target.type == MsgType.Location:
+                        refer_type = 48
+                    elif msg.target.type == MsgType.File:
+                        refer_type = 49
+                    elif comwechat_info.get("type", None) == "share":
+                        refer_type = 49
+                    else:
+                        refer_type = 1
                     if content:
                         content = "<content>%s</content>" % content
                     else:
                         content = "<content />"
-                    if "@chatroom" in msg.author.chat.uid:
-                        xml = QUOTE_GROUP_MESSAGE % (self.wxid, text, msgid, sender, sender, displayname, content)
-                    else:
-                        xml = QUOTE_MESSAGE % (self.wxid, text, msgid, sender, sender, displayname, content)
+                    xml = QUOTE_MESSAGE % (self.wxid, text_to_send, refer_type, msgid, sender, sender, displayname, content)
                     return self.bot.SendXml(wxid = wxid , xml = xml, img_path = "")
         return self.bot.SendText(wxid = wxid , msg = text)
 

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -799,7 +799,7 @@ class ComWeChatChannel(SlaveChannel):
                         "\n": "&#x0A;",
                         "\t": "&#x09;",
                         '"': "&quot;",
-                    })
+                    }) or msg.target.text
                     comwechat_info = msg.target.vendor_specific.get("comwechat_info", {})
                     if comwechat_info.get("type", None) == "animatedsticker":
                         refer_type = 47

--- a/efb_wechat_comwechat_slave/Constant.py
+++ b/efb_wechat_comwechat_slave/Constant.py
@@ -1,54 +1,3 @@
-QUOTE_GROUP_MESSAGE="""<msg>
-    <fromusername>%s</fromusername>
-    <scene>0</scene>
-    <commenturl></commenturl>
-    <appmsg appid="" sdkver="0">
-        <title>%s</title>
-        <des></des>
-        <action>view</action>
-        <type>57</type>
-        <showtype>0</showtype>
-        <content></content>
-        <url></url>
-        <dataurl></dataurl>
-        <lowurl></lowurl>
-        <lowdataurl></lowdataurl>
-        <recorditem></recorditem>
-        <thumburl></thumburl>
-        <messageaction></messageaction>
-        <refermsg>
-            <type>1</type>
-            <svrid>%s</svrid>
-            <fromusr>%s</fromusr>
-            <chatusr>%s</chatusr>
-            <displayname>%s</displayname>
-            %s
-        </refermsg>
-        <extinfo></extinfo>
-        <sourceusername></sourceusername>
-        <sourcedisplayname></sourcedisplayname>
-        <commenturl></commenturl>
-        <appattach>
-            <totallen>0</totallen>
-            <attachid></attachid>
-            <emoticonmd5></emoticonmd5>
-            <fileext></fileext>
-            <aeskey></aeskey>
-        </appattach>
-        <weappinfo>
-            <pagepath></pagepath>
-            <username></username>
-            <appid></appid>
-            <appservicetype>0</appservicetype>
-        </weappinfo>
-        <websearch />
-    </appmsg>
-    <appinfo>
-        <version>1</version>
-        <appname>Window wechat</appname>
-    </appinfo>
-</msg>
-"""
 QUOTE_MESSAGE="""<msg>
     <fromusername>%s</fromusername>
     <scene>0</scene>
@@ -68,7 +17,7 @@ QUOTE_MESSAGE="""<msg>
         <thumburl></thumburl>
         <messageaction></messageaction>
         <refermsg>
-            <type>1</type>
+            <type>%d</type>
             <svrid>%s</svrid>
             <fromusr>%s</fromusr>
             <chatusr>%s</chatusr>

--- a/efb_wechat_comwechat_slave/MsgProcess.py
+++ b/efb_wechat_comwechat_slave/MsgProcess.py
@@ -12,13 +12,15 @@ from lxml import etree
 from ehforwarderbot import utils as efb_utils
 from ehforwarderbot.message import Message
 
-def MsgWrapper(xml, efb_msgs:  Union[Message, List[Message]]):
+def MsgWrapper(msg, efb_msgs:  Union[Message, List[Message]]):
     efb_msgs = [efb_msgs] if isinstance(efb_msgs, Message) else efb_msgs
     if not efb_msgs:
         return
     for efb_msg in efb_msgs:
         vendor_specific = getattr(efb_msg, "vendor_specific", {})
+        xml = msg.pop("message", None)
         vendor_specific["wx_xml"] = xml
+        vendor_specific["comwechat_info"] = msg
         setattr(efb_msg, "vendor_specific", vendor_specific)
     return efb_msgs
 


### PR DESCRIPTION
mac Version 4.0.6.19 会根据 refermsg/type 判断处理逻辑，需要传入不同的消息类型对应的 type，否则会显示裸的 xml 格式。旧版本没有这个问题

<img width="1672" height="1332" alt="PixPin_2025-07-17_15-20-16" src="https://github.com/user-attachments/assets/29148f12-c246-4228-856b-7f2d6dbd1606" />
