### PR TITLE
feat: add group announcement

### DIFF
--- a/efb_wechat_comwechat_slave/MsgDeco.py
+++ b/efb_wechat_comwechat_slave/MsgDeco.py
@@ -755,6 +755,10 @@ def efb_other_wrapper(text: str) -> Union[Message, None]:
             vendor_specific={ "is_mp": False }
             )
 
+    elif msg_type == "mmchatroombarannouncememt":
+        text = xml.xpath('/sysmsg/mmchatroombarannouncememt/content/text()')[0]
+        efb_msg = efb_text_simple_wrapper(text)
+
     if efb_msg:
         return efb_msg
     else:

--- a/efb_wechat_comwechat_slave/MsgDeco.py
+++ b/efb_wechat_comwechat_slave/MsgDeco.py
@@ -538,13 +538,13 @@ def efb_share_link_wrapper(message: dict, chat) -> Message:
                 text=result_text,
                 vendor_specific={ "is_mp": True }
             )
-        elif type == 87: # 群公告
-            title = xml.xpath('/msg/appmsg/textannouncement/text()')[0]
-            efb_msg = Message(
-                type=MsgType.Text,
-                text= f"[群公告]:\n{title}" ,
-                vendor_specific={ "is_mp": False }
-            )
+        # elif type == 87: # 群公告
+        #     title = xml.xpath('/msg/appmsg/textannouncement/text()')[0]
+        #     efb_msg = Message(
+        #         type=MsgType.Text,
+        #         text= f"[群公告]:\n{title}" ,
+        #         vendor_specific={ "is_mp": False }
+        #     )
         elif type == 2000:
             subtype = xml.xpath("/msg/appmsg/wcpayinfo/paysubtype/text()")[0]
             money =  xml.xpath("/msg/appmsg/wcpayinfo/feedesc/text()")[0].strip("<![CDATA[").strip("]]>")
@@ -756,8 +756,12 @@ def efb_other_wrapper(text: str) -> Union[Message, None]:
             )
 
     elif msg_type == "mmchatroombarannouncememt":
-        text = xml.xpath('/sysmsg/mmchatroombarannouncememt/content/text()')[0]
-        efb_msg = efb_text_simple_wrapper(text)
+        title = xml.xpath('/sysmsg/mmchatroombarannouncememt/content/text()')[0]
+        efb_msg = Message(
+            type=MsgType.Text,
+            text= f"[群公告]:\n{title}" ,
+            vendor_specific={ "is_mp": False }
+        )
 
     if efb_msg:
         return efb_msg

--- a/efb_wechat_comwechat_slave/MsgDeco.py
+++ b/efb_wechat_comwechat_slave/MsgDeco.py
@@ -538,7 +538,8 @@ def efb_share_link_wrapper(message: dict, chat) -> Message:
                 text=result_text,
                 vendor_specific={ "is_mp": True }
             )
-        # elif type == 87: # 群公告
+        elif type == 87: # 群公告
+            return
         #     title = xml.xpath('/msg/appmsg/textannouncement/text()')[0]
         #     efb_msg = Message(
         #         type=MsgType.Text,

--- a/efb_wechat_comwechat_slave/MsgDeco.py
+++ b/efb_wechat_comwechat_slave/MsgDeco.py
@@ -673,7 +673,7 @@ def efb_voice_wrapper(file: IO, filename: str = None, text: str = None) -> Messa
         efb_msg.text = text
     return efb_msg
 
-def efb_other_wrapper(text: str) -> Union[Message, None]:
+def efb_other_wrapper(text: str, chat) -> Union[Message, None]:
     """
     A simple EFB message wrapper for other message
     :param text: The content of the message
@@ -757,10 +757,13 @@ def efb_other_wrapper(text: str) -> Union[Message, None]:
 
     elif msg_type == "mmchatroombarannouncememt":
         title = xml.xpath('/sysmsg/mmchatroombarannouncememt/content/text()')[0]
+        at_list = {}
+        at_list[(1, 4)] = chat.self
         efb_msg = Message(
             type=MsgType.Text,
             text= f"[群公告]:\n{title}" ,
-            vendor_specific={ "is_mp": False }
+            vendor_specific={ "is_mp": False },
+            substitutions = Substitutions(at_list)
         )
 
     if efb_msg:

--- a/efb_wechat_comwechat_slave/MsgProcess.py
+++ b/efb_wechat_comwechat_slave/MsgProcess.py
@@ -90,7 +90,7 @@ def MsgProcess(msg : dict , chat) -> Union[Message, List[Message]]:
             return efb_text_simple_wrapper(f"[{content}]")
 
     elif msg["type"] == "other":
-        return efb_other_wrapper(msg["message"])
+        return efb_other_wrapper(msg["message"], chat)
 
     elif msg["type"] == "phone":
         return


### PR DESCRIPTION
如果是已加群状态，微信会发送两条群公告消息，一条是 share 87 类型，一条是 other mmchatroombarannouncememt 类型。如果是加入已存在群公告的群，微信只会发送 other mmchatroombarannouncememt 类型的消息

<img width="634" height="278" alt="PixPin_2025-07-23_15-40-15" src="https://github.com/user-attachments/assets/13a785b9-0834-44ef-bb73-ef21343bd8b2" />

这个 pr 将群公告消息改为识别 other mmchatroombarannouncememt 类型消息以在加入某个群时在 tg 端能够看到群公告，并添加了群公告 at 功能