### PR TITLE
feat: extract alias from msg

### DIFF
--- a/efb_wechat_comwechat_slave/ChatMgr.py
+++ b/efb_wechat_comwechat_slave/ChatMgr.py
@@ -58,11 +58,15 @@ class ChatMgr:
         :return: Newly built ChatMember
         """
         with contextlib.suppress(KeyError):
-            return chat.get_member(str(member.get('uid', '')))
-        efb_chat: ChatMember = chat.add_member(
+            m = chat.get_member(str(member.get('uid', '')))
+        m: ChatMember = chat.add_member(
             **member
         )
-        return efb_chat
+        if member.get('name', None) is not None:
+            m.name = member.get('name')
+        if member.get('alias', None) is not None:
+            m.alias = member.get('alias')
+        return m
 
     @staticmethod
     def build_efb_chat_as_system_user(chat: EFBSystemUser):

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -897,10 +897,10 @@ class ComWeChatChannel(SlaveChannel):
         t.start()
 
     def send_status(self, status: 'Status'):
-        self.db.stop_worker()
+        ...
 
     def stop_polling(self):
-        ...
+        self.db.stop_worker()
 
     def get_message_by_id(self, chat: 'Chat', msg_id: MessageID) -> Optional['Message']:
         ...

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -57,6 +57,7 @@ class ComWeChatChannel(SlaveChannel):
     groups : EFBGroupChat    = []
 
     contacts : Dict = {}            # {wxid : {alias : str , remark : str, nickname : str , type : int}} -> {wxid : name(after handle)}
+    nicknames : Dict = {}
     group_members : Dict = {}       # {"group_id" : { "wxID" : "displayName"}}
 
     time_out : int = 120
@@ -161,11 +162,14 @@ class ComWeChatChannel(SlaveChannel):
             except:
                 name = wxid
             self.extract_alias(msg)
+            alias = self.group_members.get(sender,{}).get(wxid , None)
+            if alias == self.nicknames.get(wxid, None):
+                alias = None
 
             author = ChatMgr.build_efb_chat_as_member(chat, EFBGroupMember(
                 uid = wxid,
                 name = name,
-                alias = self.group_members.get(sender,{}).get(wxid , None),
+                alias = alias
             ))
             self.handle_msg(msg, author, chat)
 
@@ -186,7 +190,7 @@ class ComWeChatChannel(SlaveChannel):
                 xml = etree.fromstring(msg["message"])
                 text = xml.xpath('string(/sysmsg/revokemsg/replacemsg)')
                 alias = re.search(r'^"(.*?)" (撤回了一条消息|recalled a message)$', text)
-                if alias and alias.group(1) != self.get_name_by_wxid(wxid):
+                if alias and alias.group(1) != self.get_nickname_by_wxid(wxid):
                     self.merge_group_members(sender, {
                         wxid: alias.group(1)
                     })
@@ -887,9 +891,28 @@ class ComWeChatChannel(SlaveChannel):
                 name = data[3]
                 if name == "":
                     name = wxid
+                else:
+                    self.contacts[wxid] = name
             else:
                 name = wxid
         return name
+
+    def get_nickname_by_wxid(self, wxid):
+        try:
+            nickname = self.nicknames[wxid]
+            if nickname == "":
+                nickname = wxid
+        except:
+            data = self.bot.GetContactBySql(wxid = wxid)
+            if data:
+                nickname = data[2]
+                if nickname == "":
+                    nickname = wxid
+                else:
+                    self.nicknames[wxid] = nickname
+            else:
+                nickname = wxid
+        return nickname
 
     #定时更新 Start
     def GetContactListBySql(self):
@@ -901,6 +924,7 @@ class ComWeChatChannel(SlaveChannel):
             name = (f"{data['remark']}({data['nickname']})") if data["remark"] else data["nickname"]
 
             self.contacts[contact] = name
+            self.nicknames[contact] = data["nickname"]
             if data["type"] == 0 or data["type"] == 4:
                 continue
 
@@ -942,7 +966,7 @@ class ComWeChatChannel(SlaveChannel):
             xml = etree.fromstring(msg["message"])
             id = xml.xpath('string(/msg/appmsg/refermsg/chatusr)')
             alias = xml.xpath('string(/msg/appmsg/refermsg/displayname)')
-            name = self.get_name_by_wxid(id)
+            name = self.get_nickname_by_wxid(id)
             if alias and alias != name:
                 extracted = True
                 self.merge_group_members(sender, {
@@ -955,7 +979,7 @@ class ComWeChatChannel(SlaveChannel):
             user_list = [user for user in at_user.split(",") if user]
             if len(user_list) == 1:
                 try:
-                    name = self.get_name_by_wxid(user_list[0])
+                    name = self.get_nickname_by_wxid(user_list[0])
                     alias = re.search("^@(.*)\u2005", msg["message"]).group(1)
                     if alias != name:
                         self.merge_group_members(sender, {

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -930,7 +930,7 @@ class ComWeChatChannel(SlaveChannel):
         except:
             data = self.bot.GetContactBySql(wxid = wxid)
             if data:
-                nickname = data[2]
+                nickname = data[3]
                 if nickname == "":
                     nickname = wxid
                 else:

--- a/efb_wechat_comwechat_slave/db.py
+++ b/efb_wechat_comwechat_slave/db.py
@@ -1,0 +1,67 @@
+import logging
+
+from peewee import (
+    CharField,
+    DoesNotExist,
+    Model,
+    TextField,
+)
+from playhouse.sqliteq import SqliteQueueDatabase
+from ehforwarderbot import utils
+
+database = SqliteQueueDatabase(None, autostart=False)
+
+
+class BaseModel(Model):
+    class Meta:
+        database = database
+
+
+class GroupChatInfo(BaseModel):
+    group_uid = CharField()
+    wxid = CharField()
+    group_alias = TextField()
+
+    class Meta:
+        indexes = (
+            (('group_uid', 'wxid'), True),  # Unique index on group_uid and wxid
+        )
+
+
+class DatabaseManager:
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, channel: "ComWeChatChannel"):
+        base_path = utils.get_data_path(channel.channel_id)
+
+        self.logger.debug("Loading database...")
+        database.init(str(base_path / "wxdata.db"))
+        database.start()
+        database.connect()
+        self.logger.debug("Database loaded.")
+
+        self.logger.debug("Checking database migration...")
+        self._create()
+        self.logger.debug("Database migration finished...")
+
+    def stop_worker(self):
+        database.stop()
+
+    @staticmethod
+    def _create():
+        """
+        Initializing tables.
+        """
+        database.create_tables([GroupChatInfo], safe=True)
+
+    @staticmethod
+    def get_all_group_aliases():
+        return list(GroupChatInfo.select())
+
+    @staticmethod
+    def update_group_alias(group_uid, wxid, alias):
+        return GroupChatInfo.replace(
+            group_uid = group_uid,
+            wxid = wxid,
+            group_alias = alias,
+        ).execute()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "cachetools",
         "requests",
         "qrcode",
+        "peewee",
         "pyzbar",
         "python-magic",
         "lxml",


### PR DESCRIPTION
微信本身存在已知 bug 会导致群昵称无法正常获取，在小红书上有很多相关反馈。该 pr 使用新的思路从三个来源获取群昵称：
1. 撤回消息
2. 回复消息
3. at 消息

微信会在上述三种消息中添加目标的群昵称，经测试 撤回消息 和 回复消息 均能稳定获取，但 at 消息中存在多种边缘情况，为降低错误率，仅正则匹配 @ 开头且 @ 单人的消息体。

并使用 sqlite 持久化保存群昵称