### PR TITLE
fix: raise error instead

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -26,7 +26,7 @@ from . import __version__ as version
 from ehforwarderbot.channel import SlaveChannel
 from ehforwarderbot.types import MessageID, ChatID, InstanceID
 from ehforwarderbot import utils as efb_utils
-from ehforwarderbot.exceptions import EFBException, EFBChatNotFound
+from ehforwarderbot.exceptions import EFBException, EFBChatNotFound, EFBMessageError
 from ehforwarderbot.message import MessageCommand, MessageCommands
 from ehforwarderbot.status import MessageRemoval
 
@@ -780,7 +780,7 @@ class ComWeChatChannel(SlaveChannel):
 
         try:
             if str(res["msg"]) == "0":
-                self.system_msg({'sender':chat_uid, 'message':"发送失败，请在手机端确认"})
+                raise EFBMessageError("发送失败，请在手机端确认")
         except:
             ...
         return msg


### PR DESCRIPTION
目前消息发送失败之后是发送一条 system msg。
<img width="1292" height="218" alt="PixPin_2025-08-13_16-57-56" src="https://github.com/user-attachments/assets/ad00b29e-2fe2-49df-9fde-7c0f41632fb4" />
但是有一个问题是如果我发送多条消息，其中一条消息失败了我会不知道是哪条失败了。开始的思路是在 [etm](https://github.com/ehForwarderBot/efb-telegram-master/pull/146) 改，允许这条 system message 可以回复失败的消息。现在发现 [efb](https://github.com/ehForwarderBot/ehForwarderBot/blob/cb069ddaa85290893e35bcd245f59573468c6fb0/ehforwarderbot/exceptions.py#L26) 本身规定了一个 `EFBMessageError` 的错误是在这种状态下使用的，效果如下 
<img width="468" height="338" alt="PixPin_2025-08-13_17-00-31" src="https://github.com/user-attachments/assets/68e11394-8c17-40ef-871c-2bc8bda08a3c" />
