### PR TITLE
feat: send ChatUpdates after update contact list

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -28,7 +28,7 @@ from ehforwarderbot.types import MessageID, ChatID, InstanceID
 from ehforwarderbot import utils as efb_utils
 from ehforwarderbot.exceptions import EFBException, EFBChatNotFound, EFBMessageError
 from ehforwarderbot.message import MessageCommand, MessageCommands
-from ehforwarderbot.status import MessageRemoval
+from ehforwarderbot.status import MessageRemoval, ChatUpdates
 
 from .ChatMgr import ChatMgr
 from .CustomTypes import EFBGroupChat, EFBPrivateChat, EFBGroupMember, EFBSystemUser
@@ -880,8 +880,8 @@ class ComWeChatChannel(SlaveChannel):
 
     #定时更新 Start
     def GetContactListBySql(self):
-        self.groups = []
-        self.friends = []
+        new_chats = []
+        modified_chats = []
         contacts = self.bot.GetContactListBySql()
         for contact in contacts:
             data = contacts[contact]
@@ -896,13 +896,26 @@ class ComWeChatChannel(SlaveChannel):
                     uid=contact,
                     name=name
                 )
-                self.groups.append(ChatMgr.build_efb_chat_as_group(new_entity))
+                try:
+                    self.get_chat(contact)
+                    modified_chats.append(contact)
+                except EFBChatNotFound:
+                    self.groups.append(ChatMgr.build_efb_chat_as_group(new_entity))
+                    new_chats.append(contact)
             else:
                 new_entity = EFBPrivateChat(
                     uid=contact,
                     name=name
                 )
-                self.friends.append(ChatMgr.build_efb_chat_as_private(new_entity))
+                try:
+                    self.get_chat(contact)
+                    modified_chats.append(contact)
+                except EFBChatNotFound:
+                    self.friends.append(ChatMgr.build_efb_chat_as_private(new_entity))
+                    new_chats.append(contact)
+
+        if new_chats or modified_chats:
+            coordinator.send_status(ChatUpdates(channel=self, new_chats=new_chats, modified_chats=modified_chats))
 
     def GetGroupListBySql(self):
         self.group_members = self.bot.GetAllGroupMembersBySql()


### PR DESCRIPTION
[etm](https://github.com/jiz4oh/efb-telegram-master/blob/b97d9da6aa4303cd167d0060a1d31b30bdd911b9/efb_telegram_master/slave_message.py#L981-L989) 使用 ChatUpdates 更新内部 chat list 缓存以供后续使用

这个 pr 在更新 GetContactListBySql 的时候发送 ChatUpdates，主要用途是在好友更新了名称之后不需要重启 efb 就可以在 tg 端使用 /update_info 更新名称