### PR TITLE
fix: show sender on card msg

### DIFF
--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -308,7 +308,7 @@ class ComWeChatChannel(SlaveChannel):
                 if sender == wxid:
                     author = chat.self
                 else:
-                    alias = self.get_nickname_by_wxid(wxid)
+                    alias = self.group_members.get(sender,{}).get(wxid , None),
                     alias = None if alias == name else alias
                     author = ChatMgr.build_efb_chat_as_member(chat, EFBGroupMember(
                         uid = wxid,

--- a/efb_wechat_comwechat_slave/ComWechat.py
+++ b/efb_wechat_comwechat_slave/ComWechat.py
@@ -300,13 +300,38 @@ class ComWeChatChannel(SlaveChannel):
                 )
             ]
 
-            content["sender"] = sender
-            content["message"] = text
-            content["name"] = name
+            if "@chatroom" in sender:
+                chat = ChatMgr.build_efb_chat_as_group(EFBGroupChat(
+                    uid = sender,
+                    name = self.get_name_by_wxid(sender)
+                ))
+                if sender == wxid:
+                    author = chat.self
+                else:
+                    alias = self.get_nickname_by_wxid(wxid)
+                    alias = None if alias == name else alias
+                    author = ChatMgr.build_efb_chat_as_member(chat, EFBGroupMember(
+                        uid = wxid,
+                        name = name,
+                        alias = alias
+                    ))
+            else:
+                chat = ChatMgr.build_efb_chat_as_private(EFBPrivateChat(
+                    uid = sender,
+                    name = name,
+                ))
+                author = chat.self if sender == self.wxid else chat.other
+                if sender.startswith('gh_'):
+                    chat.vendor_specific = {'is_mp' : True}
+
             # if "v3" in username:
             #     content["commands"] = commands
             # 暂时屏蔽
-            self.system_msg(content)
+            m = Message(
+                type=MsgType.Text,
+                text=text
+            )
+            self.send_efb_msgs(MsgWrapper(msg, m), author=author, chat=chat, uid=MessageID(str(msg['msgid'])))
 
     def login(self):
         self.master_qr_picture_id = None


### PR DESCRIPTION
现在的名片信息是用 system msg 发送，在群里的显示格式如下：

<img width="366" height="290" alt="PixPin_2025-08-22_23-34-20" src="https://github.com/user-attachments/assets/427c4b1c-cac8-45bd-9142-425d513059ce" />

我无法知道具体是哪一个群友发送的名片消息。

修改之后如下：

<img width="438" height="276" alt="PixPin_2025-08-22_23-35-33" src="https://github.com/user-attachments/assets/8dae8be2-ec1e-4582-bf5b-941f70704882" />
