### PR TITLE
feat: add title for share card

### DIFF
--- a/efb_wechat_comwechat_slave/MsgDeco.py
+++ b/efb_wechat_comwechat_slave/MsgDeco.py
@@ -223,7 +223,7 @@ def efb_share_link_wrapper(message: dict, chat) -> Message:
     //appmsg/type = 19 : 合并转发的聊天记录
     //appmsg/type = 21 : 微信运动
     //appmsg/type = 24 : 从收藏中分享的笔记
-    //appmsg/type = 33 : 美团外卖
+    //appmsg/type = 33 : 美团外卖/腾讯微证券
     //appmsg/type = 35 : 消息同步
     //appmsg/type = 36 : 京东农场，滴滴打车
     //appmsg/type = 51 : 视频（微信视频号分享）
@@ -408,10 +408,11 @@ def efb_share_link_wrapper(message: dict, chat) -> Message:
             )
         elif type == 33:
             sourcedisplayname = xml.xpath('/msg/appmsg/sourcedisplayname/text()')[0]
+            title = xml.xpath('string(/msg/appmsg/title)')
             weappiconurl = xml.xpath('/msg/appmsg/weappinfo/weappiconurl/text()')[0]
             url = xml.xpath('/msg/appmsg/url/text()')[0]
             attribute = LinkAttribute(
-                title=sourcedisplayname,
+                title=f"{sourcedisplayname}\n{title}",
                 description=None,
                 url=url,
                 image=weappiconurl


### PR DESCRIPTION
<img width="706" height="196" alt="PixPin_2025-08-26_10-24-19" src="https://github.com/user-attachments/assets/88cf51ac-c44b-4da3-b1ab-68c766857842" />

之前 type 33 只获取了 sourcedisplayname，但是点进去其实什么都看不见，只有在手机上打开才知道具体内容。这个 pr 增加了 title 信息，效果如下：

<img width="642" height="128" alt="PixPin_2025-08-26_10-24-29" src="https://github.com/user-attachments/assets/13865173-eee3-4cf5-9697-5d4de87744cc" />
