### PR TITLE
feat: display poiname instead of label

### DIFF
--- a/efb_wechat_comwechat_slave/MsgDeco.py
+++ b/efb_wechat_comwechat_slave/MsgDeco.py
@@ -573,10 +573,10 @@ def efb_share_link_wrapper(message: dict, chat) -> Message:
 
 def efb_location_wrapper(msg: str) -> Message:
     efb_msg = Message()
-    label = re.search('''label="(.*?)"''', msg).group(1)
+    text = re.search('''poiname="(.*?)"''', msg).group(1)
     x = re.search('''x="(.*?)"''', msg).group(1)
     y = re.search('''y="(.*?)"''', msg).group(1)
-    efb_msg.text = label
+    efb_msg.text = text
     efb_msg.attributes = LocationAttribute(latitude=float(x),
                                            longitude=float(y))
     efb_msg.type = MsgType.Location


### PR DESCRIPTION
现在获取的 label 显示的是具体地点名，如下，有时候这个地点名看得让人比较懵逼不知道是什么地方，需要点进地图去看

<img width="668" height="490" alt="PixPin_2025-09-02_16-45-04" src="https://github.com/user-attachments/assets/d15d2c23-c261-4ee7-ac71-971c623f5124" />

改为获取 poiname 之后会好些

<img width="646" height="470" alt="PixPin_2025-09-02_16-44-01" src="https://github.com/user-attachments/assets/90520646-a497-4d74-95be-041bca2f88b4" />

也可以考虑其他显示格式，比如 `f"{poiname}({label})"` @0honus0 你怎么看？
